### PR TITLE
remove the friend declaration in f8_scoped_lock_impl 

### DIFF
--- a/include/ff_wrapper.hpp
+++ b/include/ff_wrapper.hpp
@@ -265,8 +265,6 @@ public:
 		_local_mutex->unlock();
 		_local_mutex = 0;
 	}
-
-	friend T;
 };
 
 typedef f8_scoped_lock_impl<f8_mutex> f8_scoped_lock;


### PR DESCRIPTION
remove the friend declaration as there is no longer a statement of the class that will be the friend of f8_scoped_lock_impl. this will allow fix8 to build.
