### PR TITLE
Make include guards standard-compliant.

### DIFF
--- a/compiler/f8c.hpp
+++ b/compiler/f8c.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _F8_F8C_HPP_
-#define _F8_F8C_HPP_
+#ifndef FIX8_F8C_HPP_
+#define FIX8_F8C_HPP_
 
 //-------------------------------------------------------------------------------------------------
 namespace FIX8 {

--- a/include/fix8/configuration.hpp
+++ b/include/fix8/configuration.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_CONFIGURATION_HPP_
-# define _FIX8_CONFIGURATION_HPP_
+#ifndef FIX8_CONFIGURATION_HPP_
+#define FIX8_CONFIGURATION_HPP_
 
 #ifdef HAVE_OPENSSL
 #include <openssl/ssl.h>

--- a/include/fix8/connection.hpp
+++ b/include/fix8/connection.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_CONNECTION_HPP_
-# define _FIX8_CONNECTION_HPP_
+#ifndef FIX8_CONNECTION_HPP_
+#define FIX8_CONNECTION_HPP_
 
 #include <Poco/Net/StreamSocket.h>
 #include <Poco/Timespan.h>

--- a/include/fix8/consolemenu.hpp
+++ b/include/fix8/consolemenu.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_CONSOLEMENU_HPP_
-# define _FIX8_CONSOLEMENU_HPP_
+#ifndef FIX8_CONSOLEMENU_HPP_
+#define FIX8_CONSOLEMENU_HPP_
 
 //-------------------------------------------------------------------------------------------------
 namespace FIX8 {

--- a/include/fix8/f8dll.h
+++ b/include/fix8/f8dll.h
@@ -33,8 +33,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _F8DLL_H_INCLUDED_
-#define _F8DLL_H_INCLUDED_
+#ifndef FIX8_DLL_H_INCLUDED_
+#define FIX8_DLL_H_INCLUDED_
 
 #if defined(_MSC_VER)
     #if defined(BUILD_F8API)

--- a/include/fix8/f8exception.hpp
+++ b/include/fix8/f8exception.hpp
@@ -33,8 +33,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _F8_EXCEPTION_HPP_
-# define _F8_EXCEPTION_HPP_
+#ifndef FIX8_EXCEPTION_HPP_
+#define FIX8_EXCEPTION_HPP_
 
 //-------------------------------------------------------------------------------------------------
 #include <string>

--- a/include/fix8/f8includes.hpp
+++ b/include/fix8/f8includes.hpp
@@ -33,8 +33,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_INCLUDES_HPP_
-# define _FIX8_INCLUDES_HPP_
+#ifndef FIX8_INCLUDES_HPP_
+#define FIX8_INCLUDES_HPP_
 
 #include <f8dll.h>
 #include <f8config.h>

--- a/include/fix8/f8types.hpp
+++ b/include/fix8/f8types.hpp
@@ -33,8 +33,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _F8_TYPES_HPP_
-# define _F8_TYPES_HPP_
+#ifndef FIX8_TYPES_HPP_
+#define FIX8_TYPES_HPP_
 
 //-------------------------------------------------------------------------------------------------
 #include <map>

--- a/include/fix8/f8utils.hpp
+++ b/include/fix8/f8utils.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-----------------------------------------------------------------------------------------
-#ifndef _F8_UTILS_HPP_
-# define _F8_UTILS_HPP_
+#ifndef FIX8_UTILS_HPP_
+#define FIX8_UTILS_HPP_
 
 //-----------------------------------------------------------------------------------------
 #include <Poco/DateTime.h>

--- a/include/fix8/ff_wrapper.hpp
+++ b/include/fix8/ff_wrapper.hpp
@@ -33,8 +33,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_FF_WRAPPER_HPP_
-# define _FIX8_FF_WRAPPER_HPP_
+#ifndef FIX8_FF_WRAPPER_HPP_
+#define FIX8_FF_WRAPPER_HPP_
 
 //-------------------------------------------------------------------------------------------------
 namespace FIX8 {

--- a/include/fix8/field.hpp
+++ b/include/fix8/field.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_FIELD_HPP_
-# define _FIX8_FIELD_HPP_
+#ifndef FIX8_FIELD_HPP_
+#define FIX8_FIELD_HPP_
 
 #include <Poco/Timestamp.h>
 #include <Poco/DateTime.h>

--- a/include/fix8/hypersleep.hpp
+++ b/include/fix8/hypersleep.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-----------------------------------------------------------------------------------------
-#ifndef _F8_HYPERSLEEP_
-# define _F8_HYPERSLEEP_
+#ifndef FIX8_HYPERSLEEP_HPP_
+#define FIX8_HYPERSLEEP_HPP_
 
 namespace FIX8 {
 

--- a/include/fix8/logger.hpp
+++ b/include/fix8/logger.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_LOGGER_HPP_
-#define _FIX8_LOGGER_HPP_
+#ifndef FIX8_LOGGER_HPP_
+#define FIX8_LOGGER_HPP_
 
 //-------------------------------------------------------------------------------------------------
 #include <list>

--- a/include/fix8/message.hpp
+++ b/include/fix8/message.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_MESSAGE_HPP_
-# define _FIX8_MESSAGE_HPP_
+#ifndef FIX8_MESSAGE_HPP_
+#define FIX8_MESSAGE_HPP_
 
 #if defined HAS_TR1_UNORDERED_MAP
 # include <tr1/unordered_map>

--- a/include/fix8/mpmc.hpp
+++ b/include/fix8/mpmc.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_MPMC_HPP_
-# define _FIX8_MPMC_HPP_
+#ifndef FIX8_MPMC_HPP_
+#define FIX8_MPMC_HPP_
 
 //-------------------------------------------------------------------------------------------------
 // provide generic names to Multi Producer Multi Consumer queues, mutexes and atomic from

--- a/include/fix8/persist.hpp
+++ b/include/fix8/persist.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_PERSIST_HPP_
-# define _FIX8_PERSIST_HPP_
+#ifndef FIX8_PERSIST_HPP_
+#define FIX8_PERSIST_HPP_
 
 #if defined HAVE_BDB
 # include <db_cxx.h>

--- a/include/fix8/session.hpp
+++ b/include/fix8/session.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_SESSION_HPP_
-# define _FIX8_SESSION_HPP_
+#ifndef FIX8_SESSION_HPP_
+#define FIX8_SESSION_HPP_
 
 #include <Poco/Net/StreamSocket.h>
 

--- a/include/fix8/sessionwrapper.hpp
+++ b/include/fix8/sessionwrapper.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_SESSIONWRAPPER_HPP_
-# define _FIX8_SESSIONWRAPPER_HPP_
+#ifndef FIX8_SESSIONWRAPPER_HPP_
+#define FIX8_SESSIONWRAPPER_HPP_
 
 #include <Poco/Net/ServerSocket.h>
 #ifdef HAVE_OPENSSL

--- a/include/fix8/thread.hpp
+++ b/include/fix8/thread.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-----------------------------------------------------------------------------------------
-#ifndef _FIX8_THREAD_HPP_
-# define _FIX8_THREAD_HPP_
+#ifndef FIX8_THREAD_HPP_
+#define FIX8_THREAD_HPP_
 
 //----------------------------------------------------------------------------------------
 #include<pthread.h>

--- a/include/fix8/tickval.hpp
+++ b/include/fix8/tickval.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_TICKVAL_HPP_
-# define _FIX8_TICKVAL_HPP_
+#ifndef FIX8_TICKVAL_HPP_
+#define FIX8_TICKVAL_HPP_
 
 //-------------------------------------------------------------------------------------------------
 #ifndef _MSC_VER

--- a/include/fix8/timer.hpp
+++ b/include/fix8/timer.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_TIMER_HPP_
-# define _FIX8_TIMER_HPP_
+#ifndef FIX8_TIMER_HPP_
+#define FIX8_TIMER_HPP_
 
 //-------------------------------------------------------------------------------------------------
 #include <iomanip>

--- a/include/fix8/traits.hpp
+++ b/include/fix8/traits.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_TRAITS_HPP_
-# define _FIX8_TRAITS_HPP_
+#ifndef FIX8_TRAITS_HPP_
+#define FIX8_TRAITS_HPP_
 
 #include <set>
 

--- a/test/hftest.hpp
+++ b/test/hftest.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_MYFIX_HPP_
-#define _FIX8_MYFIX_HPP_
+#ifndef FIX8_HFTEST_HPP_
+#define FIX8_HFTEST_HPP_
 
 //-----------------------------------------------------------------------------------------
 class hf_session_client;

--- a/test/myfix.hpp
+++ b/test/myfix.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_MYFIX_HPP_
-#define _FIX8_MYFIX_HPP_
+#ifndef FIX8_MYFIX_HPP_
+#define FIX8_MYFIX_HPP_
 
 //-----------------------------------------------------------------------------------------
 class myfix_session_client;

--- a/utests/f8headers.hpp
+++ b/utests/f8headers.hpp
@@ -34,8 +34,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_F8HEADERS_HPP_
-#define _FIX8_F8HEADERS_HPP_
+#ifndef FIX8_F8HEADERS_HPP_
+#define FIX8_F8HEADERS_HPP_
 
 #include <iostream>
 #include <memory>

--- a/utests/mockConnection.hpp
+++ b/utests/mockConnection.hpp
@@ -39,8 +39,8 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 mockConnection.hpp and mockConnection.cpp are used to supply a mock connection object for unit tests
 */
 //-------------------------------------------------------------------------------------------------
-#ifndef _FIX8_CONNECTION_HPP_
-#define _FIX8_CONNECTION_HPP_
+#ifndef FIX8_CONNECTION_HPP_
+#define FIX8_CONNECTION_HPP_
 
 #include <Poco/Net/StreamSocket.h>
 #include <Poco/Timespan.h>


### PR DESCRIPTION
Some include guards used [a name pattern which is reserved for the implementation of a C++ compiler](https://github.com/fix8/fix8/issues/49). This detail can be fixed by the deletion of leading underscores.

I suggest to make the used prefixes also consistent.
