### PR TITLE
Fix seqedit linkage failure due to missing PocoNet

### DIFF
--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -37,7 +37,7 @@ seqedit_SOURCES = seqedit.cpp precomp.cpp
 CLEANFILES =
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
-GEN_LIBS = -lstdc++
+GEN_LIBS = -lstdc++ -lPocoNet
 
 ALL_LIBS = $(GEN_LIBS) -L$(top_srcdir)/runtime
 


### PR DESCRIPTION
`seqedit` fails to link due to undefined references to Poco::Net::...::IPAddress and friends.