### PR TITLE
Fixed cleanup of sessionwrapper object.

### DIFF
--- a/include/fix8/sessionwrapper.hpp
+++ b/include/fix8/sessionwrapper.hpp
@@ -248,10 +248,18 @@ public:
 	/// Dtor.
 	virtual ~ClientSession ()
 	{
-		delete _persist;
+		session_ptr()->clear_connection( _cc );
 		delete _session;
-		delete _log;
+		_session = nullptr;
+		_persist->stop();
+		delete _persist;
+		_persist = nullptr;
+		_plog->stop();
 		delete _plog;
+		_plog = nullptr;
+		_log->stop();
+		delete _log;
+		_log = nullptr;
 	}
 
 	/*! Get a pointer to the session

--- a/include/fix8/sessionwrapper.hpp
+++ b/include/fix8/sessionwrapper.hpp
@@ -251,9 +251,14 @@ public:
 		session_ptr()->clear_connection( _cc );
 		delete _session;
 		_session = nullptr;
-		_persist->stop();
-		delete _persist;
-		_persist = nullptr;
+
+		if (_persist != nullptr)
+		{
+			_persist->stop();
+			delete _persist;
+			_persist = nullptr;
+		}
+
 		delete _plog;
 		_plog = nullptr;
 		delete _log;
@@ -648,20 +653,43 @@ public:
 	/// Dtor.
 	virtual ~SessionInstance ()
 	{
-		if (_psc != nullptr)
+		try
 		{
-			_psc->stop();
-			_psc = nullptr;
+			if (_psc != nullptr)
+			{
+				_psc->stop();
+				_psc = nullptr;
+			}
 		}
-		if (_session != nullptr)
+		catch (...)
 		{
-		delete _session;
-			_session = nullptr;
+			std::cerr << "~SessionInstance - psc exception during cleanup" << std::endl;;
 		}
-		if (_sock != nullptr)
+
+		try
 		{
-		delete _sock;
-		_sock = nullptr;
+			if (_session != nullptr)
+			{
+				delete _session;
+				_session = nullptr;
+			}
+		}
+		catch (...)
+		{
+			std::cerr << "~SessionInstance - session exception during cleanup" << std::endl;
+		}
+
+		try
+		{
+			if (_sock != nullptr)
+			{
+				delete _sock;
+				_sock = nullptr;
+			}
+		}
+		catch (...)
+		{
+			std::cerr << "~SessionInstance - _sock exception during cleanup" << std::endl;
 		}
 	}
 

--- a/include/fix8/sessionwrapper.hpp
+++ b/include/fix8/sessionwrapper.hpp
@@ -254,10 +254,8 @@ public:
 		_persist->stop();
 		delete _persist;
 		_persist = nullptr;
-		_plog->stop();
 		delete _plog;
 		_plog = nullptr;
-		_log->stop();
 		delete _log;
 		_log = nullptr;
 	}

--- a/include/fix8/sessionwrapper.hpp
+++ b/include/fix8/sessionwrapper.hpp
@@ -623,7 +623,7 @@ class SessionInstance : public SessionInstanceBase
 	Poco::Net::SocketAddress _claddr;
 	Poco::Net::StreamSocket *_sock;
 	T *_session;
-	ServerConnection _sc;
+	ServerConnection *_psc;
 
 public:
 	/// Ctor. Prepares session instance with inbound connection.
@@ -631,7 +631,7 @@ public:
 		_sf(sf),
 		_sock(new Poco::Net::StreamSocket(_sf.accept(_claddr))),
 		_session(new T(_sf._ctx, _sf.get_sender_comp_id(_sf._ses))),
-		_sc(_sock, _claddr, *_session, _sf.get_heartbeat_interval(_sf._ses), _sf.get_process_model(_sf._ses),
+		_psc(new ServerConnection(_sock, _claddr, *_session, _sf.get_heartbeat_interval(_sf._ses), _sf.get_process_model(_sf._ses),
 		_sf.get_tcp_nodelay(_sf._ses), _sf.get_tcp_reuseaddr(_sf._ses), _sf.get_tcp_linger(_sf._ses),
 		_sf.get_tcp_keepalive(_sf._ses),
 #ifdef HAVE_OPENSSL
@@ -639,7 +639,7 @@ public:
 #else
 		false
 #endif
-			)
+			))
 	{
 		_session->set_login_parameters(_sf._loginParameters);
 		_session->set_session_config(&_sf);
@@ -648,9 +648,21 @@ public:
 	/// Dtor.
 	virtual ~SessionInstance ()
 	{
+		if (_psc != nullptr)
+		{
+			_psc->stop();
+			_psc = nullptr;
+		}
+		if (_session != nullptr)
+		{
 		delete _session;
+			_session = nullptr;
+		}
+		if (_sock != nullptr)
+		{
 		delete _sock;
 		_sock = nullptr;
+		}
 	}
 
 	/*! Get a pointer to the session
@@ -662,7 +674,7 @@ public:
 	  \param send_seqnum if supplied, override the send login sequence number, set next send to seqnum+1
 	  \param recv_seqnum if supplied, override the receive login sequence number, set next recv to seqnum+1 */
 	virtual void start(bool wait, const unsigned send_seqnum=0, const unsigned recv_seqnum=0) override
-		{ _session->start(&_sc, wait, send_seqnum, recv_seqnum); }
+		{ _session->start(_psc, wait, send_seqnum, recv_seqnum); }
 
 	/// Stop the session. Cleanup.
 	virtual void stop() override { _session->stop(); }

--- a/schema/FIX43.xml
+++ b/schema/FIX43.xml
@@ -2357,7 +2357,7 @@
   </field>
   <field number='30' name='LastMkt' type='EXCHANGE' />
   <field number='31' name='LastPx' type='PRICE' />
-  <field number='32' name='LastQty' type='QTY' />
+  <field number='32' name='LastQty' type='INT' />
   <field number='33' name='LinesOfText' type='NUMINGROUP' />
   <field number='34' name='MsgSeqNum' type='SEQNUM' />
   <field number='35' name='MsgType' type='STRING'>
@@ -2432,7 +2432,7 @@
   </field>
   <field number='36' name='NewSeqNo' type='SEQNUM' />
   <field number='37' name='OrderID' type='STRING' />
-  <field number='38' name='OrderQty' type='QTY' />
+  <field number='38' name='OrderQty' type='INT' />
   <field number='39' name='OrdStatus' type='CHAR'>
    <value enum='0' description='NEW' />
    <value enum='1' description='PARTIALLY_FILLED' />
@@ -2698,8 +2698,8 @@
   <field number='107' name='SecurityDesc' type='STRING' />
   <field number='108' name='HeartBtInt' type='INT' />
   <field number='109' name='ClientID' type='STRING' />
-  <field number='110' name='MinQty' type='QTY' />
-  <field number='111' name='MaxFloor' type='QTY' />
+  <field number='110' name='MinQty' type='INT' />
+  <field number='111' name='MaxFloor' type='INT' />
   <field number='112' name='TestReqID' type='STRING' />
   <field number='113' name='ReportToExch' type='BOOLEAN'>
    <value enum='Y' description='YES' />


### PR DESCRIPTION
This will cleanup the sessionwrapper so that it can be destroyed when a connection is lost.  This allows a manual command to be created in the application that uses fix8 so that the session can be reconnected.  It depends on the previous patch to the connection code for clearing the connection using clear_connection.