### PR TITLE
Fix f8c unhandled exception while stoul'ing fields

### DIFF
--- a/compiler/f8c.cpp
+++ b/compiler/f8c.cpp
@@ -467,12 +467,16 @@ int load_fields(XmlElement& xf, FieldSpecMap& fspec)
          const auto bmitr(FieldSpec::_baseTypeMap.find(type));
 			FieldTrait::FieldType ft(bmitr == FieldSpec::_baseTypeMap.end() ? FieldTrait::ft_untyped : bmitr->second);
 			pair<FieldSpecMap::iterator, bool> result;
-			if (ft != FieldTrait::ft_untyped)
-				result = fspec.insert({stoul(number), FieldSpec(name, ft)});
-			else
-			{
-            if (!nowarn)
-               cerr << shortName << ':' << recover_line(*pp) << ": warning: Unknown field type: " << type << " in " << name << endl;
+			if (ft != FieldTrait::ft_untyped) {
+				try {
+					result = fspec.insert({stoul(number), FieldSpec(name, ft)});
+				} catch (std::exception& e) {
+					cerr << shortName << ':' << recover_line(*pp) << ": Failed to convert (stoul) number " << number << " in " << name << endl;
+					++glob_errors;
+				}
+			} else {
+				if (!nowarn)
+					cerr << shortName << ':' << recover_line(*pp) << ": warning: Unknown field type: " << type << " in " << name << endl;
 				++glob_warnings;
 				continue;
 			}


### PR DESCRIPTION
Re-applied to dev branch and added the ++glob_errors.

This could happen when malformed input (like letters) is in the field number.

The fix prevents termination/coredump upon unhandled execption
and instead provides diagnostic information to remedy the XML file.