### PR TITLE
FX-980 Change how libtool libraries are specified.

### DIFF
--- a/include/fix8/message.hpp
+++ b/include/fix8/message.hpp
@@ -450,6 +450,8 @@ public:
 	/// empty the positions map
 	void clear_positions() { _pos.clear(); }
 
+	const Positions& get_positions() const { return _pos; }
+
 	/*! Get the number of possible fields in this message
 	  \return number of fields */
 	size_t size() const { return _fp.size(); }
@@ -1025,6 +1027,8 @@ public:
 	/*! Get pass through fields (permissive mode only)
 	    \return string of unknown pass through fields */
 	const f8String& get_unknown() const { return _unknown; }
+
+	const F8MetaCntx& get_metadata() const { return _ctx; }
 };
 
 //-------------------------------------------------------------------------------------------------

--- a/include/fix8/message.hpp
+++ b/include/fix8/message.hpp
@@ -450,8 +450,6 @@ public:
 	/// empty the positions map
 	void clear_positions() { _pos.clear(); }
 
-	const Positions& get_positions() const { return _pos; }
-
 	/*! Get the number of possible fields in this message
 	  \return number of fields */
 	size_t size() const { return _fp.size(); }
@@ -1027,8 +1025,6 @@ public:
 	/*! Get pass through fields (permissive mode only)
 	    \return string of unknown pass through fields */
 	const f8String& get_unknown() const { return _unknown; }
-
-	const F8MetaCntx& get_metadata() const { return _ctx; }
 };
 
 //-------------------------------------------------------------------------------------------------

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -96,11 +96,21 @@ endif
 if TOGGLETRACKINGASSIGNMENTS
 libmyfix_la_CXXFLAGS += -fno-var-tracking -fno-var-tracking-assignments
 endif
-f8test_LDFLAGS = $(ALL_LIBS) -lmyfix
-f8print_LDFLAGS = $(ALL_LIBS) -lmyfix
-hftest_LDFLAGS = $(ALL_LIBS) -lhftest
-hfprint_LDFLAGS = $(ALL_LIBS) -lhftest
-harness_LDFLAGS = $(ALL_LIBS) -lmyfix
+
+f8test_LDFLAGS = $(ALL_LIBS)
+f8test_LDADD = libmyfix.la
+
+f8print_LDFLAGS = $(ALL_LIBS)
+f8print_LDADD = libmyfix.la
+
+hftest_LDFLAGS = $(ALL_LIBS)
+hftest_LDADD = libhftest.la
+
+hfprint_LDFLAGS = $(ALL_LIBS)
+hfprint_LDADD = libhftest.la
+
+harness_LDFLAGS = $(ALL_LIBS)
+harness_LDADD = libmyfix.la
 
 if USECOMPRESSION
 f8test_LDFLAGS += -lz

--- a/utests/Makefile.am
+++ b/utests/Makefile.am
@@ -84,7 +84,7 @@ endif
 
 built = $(top_srcdir)/runtime
 
-required_objs = -lutest $(built)/logger.lo $(built)/f8utils.lo $(built)/gzstream.lo \
+required_objs = libutest.la $(built)/logger.lo $(built)/f8utils.lo $(built)/gzstream.lo \
 					 $(built)/message.lo $(built)/modp_numtoa.lo
 if CODECTIMING
 required_objs += $(built)/f8measure.lo


### PR DESCRIPTION
Simple fix for the automake files so the lib tool libraries can be correctly found.

https://fix8engine.atlassian.net/browse/FX-980