### PR TITLE
FX-982 conditionally compile without the register keyword with C++17

### DIFF
--- a/include/fix8/thread.hpp
+++ b/include/fix8/thread.hpp
@@ -335,7 +335,11 @@ public:
 
 	void lock()
 	{
+#if __cplusplus >= 201703L
+		int x = 0;
+#else
 		register int x = 0;
+#endif
 		while(!__sync_bool_compare_and_swap(&_isLocked, false, true))
 		{
 			if(++x >= 100000)
@@ -348,7 +352,11 @@ public:
 	bool try_lock() { return _isLocked; }
 	void unlock()
 	{
+#if __cplusplus >= 201703L
+		int x = 0;
+#else
 		register int x = 0;
+#endif
 		while(!__sync_bool_compare_and_swap(&_isLocked, true, false))
 		{
 			if(++x >= 100000)


### PR DESCRIPTION
This lets client code compile the existing Apple implementation of f8_spin_lock under C++17 with minimal changes. I've done testing with OSSpinLock, os_unfair_lock, std::atomic_flag and a implementation of pthread_spinlocks and see quite variable performance, this needs deeper investigation and a more rigorous benchmark setup before committing so I've pushing this minimal change for now. 