### PR TITLE
Fix for FX-988

### DIFF
--- a/include/fix8/connection.hpp
+++ b/include/fix8/connection.hpp
@@ -195,7 +195,9 @@ class FIXReader : public AsyncSocket<f8String>
 			rdsz = _sock->receiveBytes(_read_buffer_wptr, maxremaining);
 			if (rdsz <= 0)
 			{
-				if (errno == EAGAIN
+				if (rdsz == 0) {
+					errno = 0;
+				} else if (errno == EAGAIN
 #if defined EWOULDBLOCK && EAGAIN != EWOULDBLOCK
 					|| errno == EWOULDBLOCK
 #endif
@@ -222,7 +224,9 @@ class FIXReader : public AsyncSocket<f8String>
 			const int rdSz(_sock->receiveBytes(where + rddone, remaining));
 			if (rdSz <= 0)
 			{
-				if (errno == EAGAIN
+				if (rdSz == 0) {
+					errno = 0;
+				} else if (errno == EAGAIN
 #if defined EWOULDBLOCK && EAGAIN != EWOULDBLOCK
 					|| errno == EWOULDBLOCK
 #endif

--- a/runtime/session.cpp
+++ b/runtime/session.cpp
@@ -847,6 +847,7 @@ bool Session::heartbeat_service()
 				{
 					slout_error << e.what();
 				}
+				do_state_change(States::st_session_terminated);
 				return true;
 			}
 			else if (_state != States::st_session_terminated)


### PR DESCRIPTION
Fix for https://fix8engine.atlassian.net/browse/FX-988

Handle 0 return value from poco Net.StreamSocket correctly in FixReader