### PR TITLE
Fix Makefiles for Ubuntu 20.04

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -96,11 +96,16 @@ endif
 if TOGGLETRACKINGASSIGNMENTS
 libmyfix_la_CXXFLAGS += -fno-var-tracking -fno-var-tracking-assignments
 endif
-f8test_LDFLAGS = $(ALL_LIBS) -lmyfix
-f8print_LDFLAGS = $(ALL_LIBS) -lmyfix
-hftest_LDFLAGS = $(ALL_LIBS) -lhftest
-hfprint_LDFLAGS = $(ALL_LIBS) -lhftest
-harness_LDFLAGS = $(ALL_LIBS) -lmyfix
+f8test_LDFLAGS = $(ALL_LIBS)
+f8test_LDADD = libmyfix.la
+f8print_LDFLAGS = $(ALL_LIBS)
+f8print_LDADD = libmyfix.la
+hftest_LDFLAGS = $(ALL_LIBS)
+hftest_LDADD = libhftest.la
+hfprint_LDFLAGS = $(ALL_LIBS)
+hfprint_LDADD = libhftest.la
+harness_LDFLAGS = $(ALL_LIBS)
+harness_LDADD = libmyfix.la
 
 if USECOMPRESSION
 f8test_LDFLAGS += -lz

--- a/utests/Makefile.am
+++ b/utests/Makefile.am
@@ -84,7 +84,7 @@ endif
 
 built = $(top_srcdir)/runtime
 
-required_objs = -lutest $(built)/logger.lo $(built)/f8utils.lo $(built)/gzstream.lo \
+required_objs = -lutest.la $(built)/logger.lo $(built)/f8utils.lo $(built)/gzstream.lo \
 					 $(built)/message.lo $(built)/modp_numtoa.lo
 if CODECTIMING
 required_objs += $(built)/f8measure.lo


### PR DESCRIPTION
The following modifications to build files will permit fix8 to build on Ubuntu 20.04