### PR TITLE
Fix connection stop avoiding ENOTCONN error

### DIFF
--- a/runtime/connection.cpp
+++ b/runtime/connection.cpp
@@ -328,7 +328,7 @@ void Connection::stop()
 	scout_debug << "Connection::stop() => _reader.stop()";
 	_reader.stop();
 	if (_reader.started())
-		_reader.socket()->shutdown();
+		_reader.socket()->close();
 	_reader.join();
 }
 


### PR DESCRIPTION
The `shutdown` call may throw Poco::Net::NetException with an error `ENOTCONN 107 Transport endpoint is not connected` if the socket is already disconnected. This happened in the `FIX8::Connection` destructor and lead to termination. The method `close` is safer. 