### PR TITLE
Use shutdown for socket on stop with handling ENOTCONN error

### DIFF
--- a/runtime/connection.cpp
+++ b/runtime/connection.cpp
@@ -328,7 +328,22 @@ void Connection::stop()
 	scout_debug << "Connection::stop() => _reader.stop()";
 	_reader.stop();
 	if (_reader.started())
-		_reader.socket()->close();
+	{
+		try
+		{
+			_reader.socket()->shutdown();
+		}
+		catch (Poco::Net::NetException& e)
+		{
+			if (e.code() != ENOTCONN)
+			{
+				scout_debug << "rethrowing Poco::Exception: " << e.displayText();
+				throw;
+			}
+
+			scout_debug << e.what();
+		}
+	}
 	_reader.join();
 }
 


### PR DESCRIPTION
MR https://github.com/fix8/fix8/pull/201 wasn't correct. Blocking `recv` is not interrupted by the `close` function, only `shutdown` can interrupt it.