### PR TITLE
Clear string instead of calling empty

### DIFF
--- a/include/fix8/f8utils.hpp
+++ b/include/fix8/f8utils.hpp
@@ -459,7 +459,7 @@ public:
          target = source.substr(offset + match.SubPos(num), match.SubSize(num));
 #endif
       else
-         target.empty();
+         target.clear();
       return target;
 	}
 


### PR DESCRIPTION
In `SubExpr` it appears the intent was to empty the passed-in string should all the above `if`s fail. `std::string::empty()` was called, which only checks to see if it was empty. It does not modify the string.

This PR empties the passed-in string should the `SubExpr` method not be able to do what was asked by the caller.