### PR TITLE
Fix MemoryPersister implementation

### DIFF
--- a/include/fix8/persist.hpp
+++ b/include/fix8/persist.hpp
@@ -291,7 +291,7 @@ public:
 /// Memory based message persister.
 class MemoryPersister : public Persister
 {
-	using Store = std::map<unsigned, const f8String>;
+	using Store = std::map<unsigned, f8String>;
 	Store _store;
 
 public:

--- a/runtime/persist.cpp
+++ b/runtime/persist.cpp
@@ -364,7 +364,8 @@ unsigned MemoryPersister::get(const unsigned from, const unsigned to, Session& s
 bool MemoryPersister::put(const unsigned sender_seqnum, const unsigned target_seqnum)
 {
 	const unsigned arr[2] { sender_seqnum, target_seqnum };
-	return _store.insert({0, f8String(reinterpret_cast<const char *>(arr), sizeof(arr))}).second;
+	_store[0] = f8String(reinterpret_cast<const char *>(arr), sizeof(arr));
+	return true;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -379,7 +380,7 @@ bool MemoryPersister::get(unsigned& sender_seqnum, unsigned& target_seqnum) cons
 	Store::const_iterator itr(_store.find(0));
 	if (itr == _store.end())
 		return false;
-	const unsigned *loc(reinterpret_cast<const unsigned *>(&itr->second));
+	const unsigned *loc(reinterpret_cast<const unsigned *>(itr->second.data()));
 	sender_seqnum = *loc++;
 	target_seqnum = *loc;
    return true;


### PR DESCRIPTION
The following issues have been fixed:

1. MemoryPersister::get reads invalid memory. The address of `f8String` object was used instead of the address of the data
2. MemoryPersister::put overload that's used for sequence numbers wasn't able to update sequence numbers in the map